### PR TITLE
Added hex, c-hex and binary file output formats to the assembler.

### DIFF
--- a/assembler.py
+++ b/assembler.py
@@ -158,7 +158,6 @@ def assemble(lines):
             if words[3] < -8 or words[3] > 7: # 2s comp [-8, 7]
                 exit(f'Invalid offset for {opcode} on line {pc}')
             machine_code |= words[3] & (2 ** 4 - 1)
-
         yield machine_code
 
 
@@ -217,16 +216,15 @@ if __name__ == '__main__':
         exit_usage()
 
     try:
-        with open(assembly_filename, 'r'): pass
-    except Exception as e:
+        with open(assembly_filename, 'r') as assembly_file:
+            lines = (line.strip() for line in assembly_file)
+            machine_code_list = list(assemble(lines))
+    except IOError as e:
         exit(f"Cannot read input file '{assembly_filename}'! {str(e)}")
-
-    with open(assembly_filename, 'r') as assembly_file:
-        lines = (line.strip() for line in assembly_file)
-        machine_code_list = assemble(lines)
-        try:
-            with open(machine_code_filename, 'wb' if fmt == 'binary' else 'w') as out_file:
-                formatters[fmt](out_file, machine_code_list)
-        except Exception as e:
-            exit(f"Cannot write output file '{machine_code_filename}'! {str(e)}")
+        
+    try:
+        with open(machine_code_filename, 'wb' if fmt == 'binary' else 'w') as out_file:
+            formatters[fmt](out_file, machine_code_list)
+    except IOError as e:
+        exit(f"Cannot write output file '{machine_code_filename}'! {str(e)}")
         

--- a/assembler.py
+++ b/assembler.py
@@ -1,8 +1,6 @@
 import sys
 
 def assemble(lines):
-    machine_code_list = []
-
     # Remove comments and blanklines
     for comment_symbol in ['/', ';', '#']:
         lines = [line.split(comment_symbol)[0] for line in lines]
@@ -78,7 +76,7 @@ def assemble(lines):
         if words[0] == 'cmp':
             words = ['sub', words[1], words[2], registers[0]] # sub A B r0
         elif words[0] == 'mov':
-            words = ['add', words[1], registers[0], words[2], ] # add A r0 dest
+            words = ['add', words[1], registers[0], words[2]] # add A r0 dest
         elif words[0] == 'lsh':
             words = ['add', words[1], words[1], words[2]] # add A A dest
         elif words[0] == 'inc':


### PR DESCRIPTION
I have added the ability to select output file format to the assembler, so it is easier to use the binary in other programs.  Also I improved file i/o error display a little.

Now it prints usage:

```
usage: assembler.py <input_file> [output_file] [format]
available formats:
  lines-bin - ascii file contatining line-separated 16-bit binary numbers (default)
  hex - zero-padded 4-character hex
  c-hex - comma-separated c-style hex literals e.g. 0x1234, 0x456
  binary - binary file (big endian)
```

## Formats:

#### `lines-bin` (default, original format)
```
1000111111111000
1111111100001110
...
```

#### `hex`
```
8ff8ff0eff0dff03ff05ff02ff018e14ff...
```

#### `c-hex`
```
0x8ff8, 0xff0e, 0xff0d, 0xff03, ...
```

#### `binary`
Outputs binary file (big-endian) containing the bytecode.