### PR TITLE
Assembler: clean pseudo-instruction lowering, fix for comment parsing + NEG docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,18 @@ Single characters can be written using single or double quotes. This will resolv
 
 Ports can be written as their name with underscores between them. For example, port 246 has name "Clear Screen Buffer", so clear_screen_buffer will resolve to 246
 
+### Pseudo-instructions
+
+The assembler supports these pseudo-instructions:
+
+- `CMP A B` -> `SUB A B r0`
+- `MOV A C` -> `ADD A r0 C`
+- `LSH A C` -> `ADD A A C`
+- `INC A` -> `ADI A 1`
+- `DEC A` -> `ADI A -1`
+- `NOT A C` -> `NOR A r0 C`
+- `NEG A C` -> `SUB r0 A C`
+
 ## Running a program on the emulator
 
 - Grab the [latest release](https://github.com/AdoHTQ/Batpu2-VM/releases)

--- a/assembler.py
+++ b/assembler.py
@@ -6,7 +6,7 @@ def assemble(assembly_filename, mc_filename):
     lines = (line.strip() for line in assembly_file)
 
     # Remove comments and blanklines
-    for comment_symbol in ['//', ';', '#']:
+    for comment_symbol in ['//', '/', ';', '#']:
         lines = [line.split(comment_symbol, 1)[0] for line in lines]
     lines = [line for line in lines if line.strip()]
 

--- a/assembler.py
+++ b/assembler.py
@@ -6,8 +6,8 @@ def assemble(assembly_filename, mc_filename):
     lines = (line.strip() for line in assembly_file)
 
     # Remove comments and blanklines
-    for comment_symbol in ['/', ';', '#']:
-        lines = [line.split(comment_symbol)[0] for line in lines]
+    for comment_symbol in ['//', ';', '#']:
+        lines = [line.split(comment_symbol, 1)[0] for line in lines]
     lines = [line for line in lines if line.strip()]
 
     # Populate symbol table

--- a/assembler.py
+++ b/assembler.py
@@ -75,22 +75,24 @@ def assemble(assembly_filename, mc_filename):
             exit(f'Could not resolve {word}')
         return symbols[word]
 
+    pseudo_instructions = {
+        'cmp': (3, lambda instruction_words: ['sub', instruction_words[1], instruction_words[2], registers[0]]),
+        'mov': (3, lambda instruction_words: ['add', instruction_words[1], registers[0], instruction_words[2]]),
+        'lsh': (3, lambda instruction_words: ['add', instruction_words[1], instruction_words[1], instruction_words[2]]),
+        'inc': (2, lambda instruction_words: ['adi', instruction_words[1], '1']),
+        'dec': (2, lambda instruction_words: ['adi', instruction_words[1], '-1']),
+        'not': (3, lambda instruction_words: ['nor', instruction_words[1], registers[0], instruction_words[2]]),
+        'neg': (3, lambda instruction_words: ['sub', registers[0], instruction_words[1], instruction_words[2]]),
+    }
+
     for pc, words in enumerate(instructions):
         # Resolve pseudo-instructions
-        if words[0] == 'cmp':
-            words = ['sub', words[1], words[2], registers[0]] # sub A B r0
-        elif words[0] == 'mov':
-            words = ['add', words[1], registers[0], words[2], ] # add A r0 dest
-        elif words[0] == 'lsh':
-            words = ['add', words[1], words[1], words[2]] # add A A dest
-        elif words[0] == 'inc':
-            words = ['adi', words[1], '1'] # adi dest 1
-        elif words[0] == 'dec':
-            words = ['adi', words[1], '-1'] # adi dest -1
-        elif words[0] == 'not':
-            words = ['nor', words[1], registers[0], words[2]] # nor A r0 dest
-        elif words[0] == "neg":
-            words = ["sub", registers[0], words[1], words[2]] # sub r0 A dest
+        pseudo_instruction = pseudo_instructions.get(words[0])
+        if pseudo_instruction is not None:
+            expected_word_count, rewrite = pseudo_instruction
+            if len(words) != expected_word_count:
+                exit(f'Incorrect number of operands for {words[0]} on line {pc}')
+            words = rewrite(words)
 
         # lod/str optional offset
         if words[0] in ['lod', 'str'] and len(words) == 3:


### PR DESCRIPTION
- Replaces chained pseudo-instruction conditionals with a small rewrite table.\n- Keeps existing pseudo behavior (including NEG A C -> SUB r0 A C).\n- Adds a brief pseudo-instructions section to README.\n\nBrief, no behavior expansion beyond existing support.